### PR TITLE
fix: limit tag and referrer list page count

### DIFF
--- a/errdef/errors.go
+++ b/errdef/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrMissingReference   = errors.New("missing reference")
 	ErrNotFound           = errors.New("not found")
 	ErrSizeExceedsLimit   = errors.New("size exceeds limit")
+	ErrTooManyPages       = errors.New("too many pages")
 	ErrUnsupported        = errors.New("unsupported")
 	ErrUnsupportedVersion = errors.New("unsupported version")
 )

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -83,6 +83,14 @@ type Registry struct {
 	// If zero, the page size is determined by the remote registry.
 	ReferrerListPageSize int
 
+	// TagListMaxPages is the default maximum number of pages to fetch during
+	// tag listing. Zero means unlimited.
+	TagListMaxPages int
+
+	// ReferrerListMaxPages is the default maximum number of pages to fetch
+	// during referrer listing. Zero means unlimited.
+	ReferrerListMaxPages int
+
 	// SkipReferrersGC is the default for repositories.
 	// If false, the old referrers index will be deleted after the new one
 	// is successfully uploaded.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -123,14 +123,16 @@ type Repository struct {
 	// Reference: https://github.com/oras-project/oras-go/issues/841
 	ReferrerListPageSize int
 
-	// TagListMaxPages overrides Registry default if set.
+	// TagListMaxPages overrides Registry default if > 0.
 	// Limits the total number of pages fetched during tag listing.
-	// Zero means unlimited (use Registry.TagListMaxPages if set).
+	// If 0, Registry.TagListMaxPages is used. If that is also 0, there is no
+	// limit.
 	TagListMaxPages int
 
-	// ReferrerListMaxPages overrides Registry default if set.
+	// ReferrerListMaxPages overrides Registry default if > 0.
 	// Limits the total number of pages fetched during referrer listing.
-	// Zero means unlimited (use Registry.ReferrerListMaxPages if set).
+	// Zero means to use Registry.ReferrerListMaxPages. Referrer listing is
+	// unlimited only if the effective Registry/default value is also zero.
 	ReferrerListMaxPages int
 
 	// SkipReferrersGC overrides Registry default if set.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -123,6 +123,16 @@ type Repository struct {
 	// Reference: https://github.com/oras-project/oras-go/issues/841
 	ReferrerListPageSize int
 
+	// TagListMaxPages overrides Registry default if set.
+	// Limits the total number of pages fetched during tag listing.
+	// Zero means unlimited (use Registry.TagListMaxPages if set).
+	TagListMaxPages int
+
+	// ReferrerListMaxPages overrides Registry default if set.
+	// Limits the total number of pages fetched during referrer listing.
+	// Zero means unlimited (use Registry.ReferrerListMaxPages if set).
+	ReferrerListMaxPages int
+
 	// SkipReferrersGC overrides Registry default if set.
 	// Specifies whether to delete the dangling referrers
 	// index when referrers tag schema is utilized.
@@ -195,6 +205,8 @@ func (r *Repository) clone() *Repository {
 		ManifestMediaTypes:   slices.Clone(r.ManifestMediaTypes),
 		TagListPageSize:      r.TagListPageSize,
 		ReferrerListPageSize: r.ReferrerListPageSize,
+		TagListMaxPages:      r.TagListMaxPages,
+		ReferrerListMaxPages: r.ReferrerListMaxPages,
 		SkipReferrersGC:      r.SkipReferrersGC,
 		mirrors:              r.mirrors,
 	}
@@ -261,6 +273,30 @@ func (r *Repository) referrerListPageSize() int {
 	}
 	if r.Registry != nil {
 		return r.Registry.ReferrerListPageSize
+	}
+	return 0
+}
+
+// tagListMaxPages returns the effective maximum number of tag list pages.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) tagListMaxPages() int {
+	if r.TagListMaxPages > 0 {
+		return r.TagListMaxPages
+	}
+	if r.Registry != nil {
+		return r.Registry.TagListMaxPages
+	}
+	return 0
+}
+
+// referrerListMaxPages returns the effective maximum number of referrer list pages.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) referrerListMaxPages() int {
+	if r.ReferrerListMaxPages > 0 {
+		return r.ReferrerListMaxPages
+	}
+	if r.Registry != nil {
+		return r.Registry.ReferrerListMaxPages
 	}
 	return 0
 }
@@ -602,7 +638,11 @@ func (r *Repository) Tags(ctx context.Context, last string, fn func(tags []strin
 	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull)
 	url := buildRepositoryTagListURL(r.plainHTTP(), repoRef)
 	var err error
-	for err == nil {
+	maxPages := r.tagListMaxPages()
+	for page := 0; err == nil; page++ {
+		if maxPages > 0 && page >= maxPages {
+			return fmt.Errorf("tag listing exceeded %d pages: %w", maxPages, errdef.ErrTooManyPages)
+		}
 		url, err = r.tags(ctx, last, fn, url)
 		// clear `last` for subsequent pages
 		last = ""
@@ -723,7 +763,11 @@ func (r *Repository) referrersByAPI(ctx context.Context, desc ocispec.Descriptor
 
 	url := buildReferrersURL(r.plainHTTP(), ref, artifactType)
 	var err error
-	for err == nil {
+	maxPages := r.referrerListMaxPages()
+	for page := 0; err == nil; page++ {
+		if maxPages > 0 && page >= maxPages {
+			return fmt.Errorf("referrer listing exceeded %d pages: %w", maxPages, errdef.ErrTooManyPages)
+		}
 		url, err = r.referrersPageByAPI(ctx, artifactType, fn, url)
 	}
 	if err == errNoLink {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1265,6 +1265,58 @@ func TestRepository_Tags(t *testing.T) {
 	}
 }
 
+func TestRepository_Tags_MaxPages(t *testing.T) {
+	tagSet := [][]string{
+		{"the", "quick", "brown", "fox"},
+		{"jumps", "over", "the", "lazy"},
+		{"dog"},
+	}
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/test/tags/list" {
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		q := r.URL.Query()
+		var tags []string
+		switch q.Get("test") {
+		case "foo":
+			tags = tagSet[1]
+			w.Header().Set("Link", fmt.Sprintf(`<%s/v2/test/tags/list?test=bar>; rel="next"`, ts.URL))
+		case "bar":
+			tags = tagSet[2]
+		default:
+			tags = tagSet[0]
+			w.Header().Set("Link", `</v2/test/tags/list?test=foo>; rel="next"`)
+		}
+		result := struct {
+			Tags []string `json:"tags"`
+		}{Tags: tags}
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.Registry.PlainHTTP = true
+	repo.TagListMaxPages = 2
+
+	ctx := context.Background()
+	err = repo.Tags(ctx, "", func(got []string) error { return nil })
+	if !errors.Is(err, errdef.ErrTooManyPages) {
+		t.Errorf("Repository.Tags() error = %v, want %v", err, errdef.ErrTooManyPages)
+	}
+}
+
 func TestRepository_Predecessors(t *testing.T) {
 	manifest := []byte(`{"layers":[]}`)
 	manifestDesc := ocispec.Descriptor{
@@ -1547,6 +1599,68 @@ func TestRepository_Referrers(t *testing.T) {
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	}
+}
+
+func TestRepository_Referrers_MaxPages(t *testing.T) {
+	manifest := []byte(`{"layers":[]}`)
+	manifestDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+	referrerSet := [][]ocispec.Descriptor{
+		{{MediaType: spec.MediaTypeArtifactManifest, Size: 1, Digest: digest.FromString("1"), ArtifactType: "application/vnd.test"}},
+		{{MediaType: spec.MediaTypeArtifactManifest, Size: 2, Digest: digest.FromString("2"), ArtifactType: "application/vnd.test"}},
+		{{MediaType: spec.MediaTypeArtifactManifest, Size: 3, Digest: digest.FromString("3"), ArtifactType: "application/vnd.test"}},
+	}
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := "/v2/test/referrers/" + manifestDesc.Digest.String()
+		if r.Method != http.MethodGet || r.URL.Path != path {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		q := r.URL.Query()
+		var referrers []ocispec.Descriptor
+		switch q.Get("test") {
+		case "foo":
+			referrers = referrerSet[1]
+			w.Header().Set("Link", fmt.Sprintf(`<%s%s?test=bar>; rel="next"`, ts.URL, path))
+		case "bar":
+			referrers = referrerSet[2]
+		default:
+			referrers = referrerSet[0]
+			w.Header().Set("Link", fmt.Sprintf(`<%s?test=foo>; rel="next"`, path))
+		}
+		result := ocispec.Index{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispec.MediaTypeImageIndex,
+			Manifests: referrers,
+		}
+		w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.Registry.PlainHTTP = true
+	repo.ReferrerListMaxPages = 2
+	repo.SetReferrersCapability(true)
+
+	ctx := context.Background()
+	err = repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error { return nil })
+	if !errors.Is(err, errdef.ErrTooManyPages) {
+		t.Errorf("Repository.Referrers() error = %v, want %v", err, errdef.ErrTooManyPages)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Tags()` and `referrersByAPI()` followed server-supplied `Link` headers indefinitely with no page ceiling, allowing a malicious registry to drive unbounded round-trips and memory growth (GHSA-wv3q-vccw-6p3r).
- Adds `TagListMaxPages` and `ReferrerListMaxPages` fields to both `Registry` (default) and `Repository` (override), mirroring the existing `TagListPageSize`/`ReferrerListPageSize` pattern.
- When a limit is set and exceeded, returns a wrapped `errdef.ErrTooManyPages` so callers can detect the condition.
- Zero value (default) preserves the existing unlimited behavior for backward compatibility.

## Test plan

- [x] `TestRepository_Tags_MaxPages` — sets `TagListMaxPages=2` against a 3-page server, asserts `ErrTooManyPages`
- [x] `TestRepository_Referrers_MaxPages` — sets `ReferrerListMaxPages=2` against a 3-page server, asserts `ErrTooManyPages`
- [x] Existing `TestRepository_Tags` and `TestRepository_Referrers` pass unchanged (zero = unlimited)