### PR TITLE
fix: backport missing v2 security advisory patches to feat/everything

### DIFF
--- a/content/file/file.go
+++ b/content/file/file.go
@@ -625,6 +625,14 @@ func (s *Store) resolveWritePath(name string) (string, error) {
 		if strings.HasPrefix(rel, "../") || rel == ".." {
 			return "", ErrPathTraversalDisallowed
 		}
+		// The lexical check above prevents "../" escapes but does not resolve
+		// symlinks. A symlink component under workingDir (e.g. "out" -> "/outside")
+		// passes the lexical check yet directs writes outside workingDir.
+		// Re-check after resolving symlinks in the parent path to close that gap.
+		// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-8xwf-rjm4-xvhv
+		if err := checkSymlinkEscape(base, target); err != nil {
+			return "", err
+		}
 	}
 	if s.DisableOverwrite {
 		if _, err := os.Stat(path); err == nil {
@@ -685,4 +693,53 @@ func (s *Store) setClosed() {
 // ensureDir ensures the directories of the path exists.
 func ensureDir(path string) error {
 	return os.MkdirAll(path, 0777)
+}
+
+// checkSymlinkEscape returns ErrPathTraversalDisallowed if resolving symlinks
+// in target's ancestor directories causes it to escape base. target may not
+// yet exist, so symlinks are resolved on its deepest existing ancestor.
+func checkSymlinkEscape(base, target string) error {
+	realBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // base doesn't exist yet; no symlinks to follow
+		}
+		return err
+	}
+	realTarget, err := realPathForWrite(target)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(realBase, realTarget)
+	if err != nil {
+		return ErrPathTraversalDisallowed
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "../") || rel == ".." {
+		return ErrPathTraversalDisallowed
+	}
+	return nil
+}
+
+// realPathForWrite resolves symlinks in the deepest existing ancestor of path
+// and returns the resulting absolute path. Non-existent path components are
+// appended verbatim, matching the semantics of a file about to be created.
+func realPathForWrite(path string) (string, error) {
+	dir := filepath.Dir(path)
+	suffix := filepath.Base(path)
+	for {
+		real, err := filepath.EvalSymlinks(dir)
+		if err == nil {
+			return filepath.Join(real, suffix), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return path, nil // reached filesystem root
+		}
+		suffix = filepath.Join(filepath.Base(dir), suffix)
+		dir = parent
+	}
 }

--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -3295,6 +3295,63 @@ func TestStore_resolveWritePath_PathTraversal(t *testing.T) {
 	}
 }
 
+func TestStore_resolveWritePath_SymlinkTraversal(t *testing.T) {
+	// GHSA-8xwf-rjm4-xvhv: resolveWritePath used a lexical filepath.Rel check
+	// that passed for names like "out/secret.txt" even when "out" is a symlink
+	// pointing outside workingDir.
+	t.Run("symlink component in workingDir escaping write boundary is blocked", func(t *testing.T) {
+		tempDir := t.TempDir()
+		outside := filepath.Join(tempDir, "outside")
+		if err := os.MkdirAll(outside, 0755); err != nil {
+			t.Fatal(err)
+		}
+		workingDir := filepath.Join(tempDir, "store")
+		if err := os.MkdirAll(workingDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// "store/out" is a symlink to a directory outside workingDir.
+		if err := os.Symlink(outside, filepath.Join(workingDir, "out")); err != nil {
+			t.Skip("symlinks not available:", err)
+		}
+
+		s, err := New(workingDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		// "out/secret.txt" passes the lexical check but follows the symlink
+		// to outside/secret.txt, escaping workingDir.
+		_, err = s.resolveWritePath("out/secret.txt")
+		if !errors.Is(err, ErrPathTraversalDisallowed) {
+			t.Errorf("resolveWritePath() error = %v, want %v", err, ErrPathTraversalDisallowed)
+		}
+	})
+
+	t.Run("regular subdirectory write within workingDir still works", func(t *testing.T) {
+		tempDir := t.TempDir()
+		workingDir := filepath.Join(tempDir, "store")
+		subDir := filepath.Join(workingDir, "sub")
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		s, err := New(workingDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		got, err := s.resolveWritePath("sub/file.txt")
+		if err != nil {
+			t.Fatalf("resolveWritePath() unexpected error: %v", err)
+		}
+		if want := filepath.Join(workingDir, "sub/file.txt"); got != want {
+			t.Errorf("resolveWritePath() = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestStore_resolveWritePath_Overwrite(t *testing.T) {
 	t.Run("Target file already exists", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -233,13 +234,23 @@ func (c *Client) SetUserAgent(userAgent string) {
 // validateRealm validates the bearer token realm before credentials are sent
 // to it.
 //
-// The realm scheme must be http or https, and an http realm is rejected when
-// the registry was contacted over https (a TLS downgrade of credential
-// traffic). This check always applies.
+// The following checks always apply, regardless of Client.TrustedRealmHosts:
+//
+//   - the realm scheme must be http or https,
+//   - an http realm is rejected when the registry was contacted over https
+//     (a TLS downgrade of credential traffic),
+//   - hosts that are IP literals in loopback, link-local, private, or
+//     unspecified ranges are rejected (e.g. cloud instance metadata services
+//     such as 169.254.169.254). The IP-literal check is skipped when the realm
+//     hostname matches the registry hostname, so loopback and in-cluster
+//     deployments continue to work.
 //
 // When Client.TrustedRealmHosts is non-empty, the realm host must also match
 // either the registry host or one of the listed hosts. An empty allowlist
-// preserves the historical permissive behavior and accepts any realm host.
+// preserves the historical permissive behavior and accepts any (otherwise
+// safe) realm host.
+//
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-xf85-363p-868w
 func (c *Client) validateRealm(realm string, registryURL *url.URL) error {
 	if realm == "" {
 		return nil
@@ -259,6 +270,20 @@ func (c *Client) validateRealm(realm string, registryURL *url.URL) error {
 		}
 	default:
 		return fmt.Errorf("bearer realm %q uses unsupported scheme %q", realm, realmURL.Scheme)
+	}
+	// Reject realm hosts that are IP literals in loopback, link-local, private,
+	// or unspecified ranges (e.g. the cloud metadata service 169.254.169.254).
+	// This always applies, independent of the TrustedRealmHosts allowlist, to
+	// prevent credential exfiltration via SSRF-style realm redirection. The
+	// check is skipped when the realm shares the registry hostname so loopback
+	// and in-cluster registries keep working.
+	if ip := net.ParseIP(realmURL.Hostname()); ip != nil {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			ip.IsPrivate() || ip.IsUnspecified() {
+			if registryURL == nil || realmURL.Hostname() != registryURL.Hostname() {
+				return fmt.Errorf("bearer realm host %q is a loopback, link-local, private, or unspecified address", realmURL.Hostname())
+			}
+		}
 	}
 	// host allowlist is opt-in; an empty list accepts any realm host.
 	if len(c.TrustedRealmHosts) == 0 {

--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -159,7 +159,50 @@ func (c *Client) send(req *http.Request) (*http.Response, error) {
 	for key, values := range c.Header {
 		req.Header[key] = append(req.Header[key], values...)
 	}
-	return c.client().Do(req)
+	// Drop the Authorization header when a redirect crosses an HTTP origin
+	// (scheme, host, or port). The standard library only strips sensitive
+	// headers when the hostname changes, so a redirect to a different port on
+	// the same host would otherwise forward credentials to an unintended
+	// endpoint. Any caller-provided CheckRedirect is preserved.
+	// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+	client := c.client()
+	clientCopy := *client
+	checkRedirect := client.CheckRedirect
+	clientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 && !sameHTTPOrigin(via[len(via)-1].URL, req.URL) {
+			req.Header.Del(headerAuthorization)
+		}
+		if checkRedirect != nil {
+			return checkRedirect(req, via)
+		}
+		return nil
+	}
+	return clientCopy.Do(req)
+}
+
+// sameHTTPOrigin reports whether a and b share the same HTTP origin, i.e. the
+// same scheme and host. Default ports are normalized so that, for example,
+// "example.com" and "example.com:443" compare equal over https.
+func sameHTTPOrigin(a, b *url.URL) bool {
+	if !strings.EqualFold(a.Scheme, b.Scheme) {
+		return false
+	}
+	return canonicalHost(a) == canonicalHost(b)
+}
+
+// canonicalHost returns the lower-cased host of u with the default port for its
+// scheme applied when no explicit port is present.
+func canonicalHost(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "https":
+			port = "443"
+		case "http":
+			port = "80"
+		}
+	}
+	return strings.ToLower(u.Hostname()) + ":" + port
 }
 
 // credential resolves the credential for the given registry.
@@ -275,6 +318,9 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 	var attemptedKey string
 	cache := c.cache()
 	host := originalReq.Host
+	if host == "" {
+		host = originalReq.URL.Host
+	}
 	scheme, err := cache.GetScheme(ctx, host)
 	if err == nil {
 		switch scheme {
@@ -298,6 +344,13 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	// If the challenge came from a different origin than originally requested
+	// (e.g. the request was redirected to another host or port), do not resolve
+	// or send the registry credentials to that origin.
+	// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+	if resp.Request != nil && !sameHTTPOrigin(originalReq.URL, resp.Request.URL) {
 		return resp, nil
 	}
 

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -4180,6 +4180,7 @@ func (m *mockTokenFetcherForClient) FetchToken(ctx context.Context, params Token
 func TestClient_validateRealm(t *testing.T) {
 	registryHTTPS, _ := url.Parse("https://registry.example.com/v2/")
 	registryHTTP, _ := url.Parse("http://registry.example.com/v2/")
+	registryLoopback, _ := url.Parse("http://127.0.0.1:5000/v2/")
 	tests := []struct {
 		name    string
 		hosts   []string
@@ -4201,6 +4202,14 @@ func TestClient_validateRealm(t *testing.T) {
 		{"http realm on plain-http registry is allowed", nil, "http://auth.example.com/token", registryHTTP, false},
 		{"http realm on https registry is rejected (TLS downgrade)", nil, "http://auth.example.com/token", registryHTTPS, true},
 		{"unsupported scheme is rejected with empty allowlist", nil, "ftp://auth.example.com/token", registryHTTPS, true},
+		// IP-literal guard (always applies, even with empty allowlist)
+		// Reference: GHSA-xf85-363p-868w
+		{"IMDS IPv4 is rejected", nil, "http://169.254.169.254/latest/meta-data/", registryHTTP, true},
+		{"loopback IPv4 is rejected when registry is on a public host", nil, "http://127.0.0.1:9090/token", registryHTTPS, true},
+		{"loopback IPv6 is rejected when registry is on a public host", nil, "http://[::1]:9090/token", registryHTTPS, true},
+		{"private RFC1918 is rejected when registry is on a public host", nil, "http://10.0.0.5/token", registryHTTP, true},
+		{"loopback realm is allowed when registry shares the loopback hostname", nil, "http://127.0.0.1:9090/token", registryLoopback, false},
+		{"public realm host is not subject to the IP-literal guard", nil, "https://auth.example.com/token", registryHTTPS, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -4212,3 +4212,250 @@ func TestClient_validateRealm(t *testing.T) {
 		})
 	}
 }
+
+// TestClient_Do_Basic_Auth_RedirectAfterAuth verifies that the Authorization
+// header is not forwarded when an authenticated request is redirected to a
+// different HTTP origin (here, a different port on the same host).
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+func TestClient_Do_Basic_Auth_RedirectAfterAuth(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	var sinkGotAuth atomic.Bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sinkGotAuth.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != wantAuth {
+			w.Header().Set("Www-Authenticate", `Basic realm="origin"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// authenticated: redirect to a different origin (different port)
+		http.Redirect(w, r, sink.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatalf("invalid origin server: %v", err)
+	}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != originURL.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, originURL.Host)
+			}
+			return credentials.Credential{Username: username, Password: password}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if sinkGotAuth.Load() {
+		t.Error("Authorization header was forwarded to a redirect target on a different origin")
+	}
+}
+
+// TestClient_Do_Basic_Auth_RedirectBeforeAuth verifies that credentials are not
+// resolved or sent when the 401 challenge originates from a different HTTP
+// origin reached through a pre-authentication redirect.
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+func TestClient_Do_Basic_Auth_RedirectBeforeAuth(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+
+	var sinkGotAuth atomic.Bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sinkGotAuth.Store(true)
+		}
+		w.Header().Set("Www-Authenticate", `Basic realm="sink"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer sink.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// redirect to a different origin before any authentication happens
+		http.Redirect(w, r, sink.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatalf("invalid origin server: %v", err)
+	}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != originURL.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, originURL.Host)
+			}
+			return credentials.Credential{Username: username, Password: password}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if sinkGotAuth.Load() {
+		t.Error("credential was forwarded to a sink reached through a pre-auth redirect")
+	}
+}
+
+// TestClient_Do_Basic_Auth_SameOriginRedirect verifies that credentials are
+// still forwarded across a same-origin redirect (e.g. a path-only redirect),
+// guarding against an over-broad fix.
+func TestClient_Do_Basic_Auth_SameOriginRedirect(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	var targetAuthOK atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect":
+			http.Redirect(w, r, "/target", http.StatusTemporaryRedirect)
+		case "/target":
+			if r.Header.Get("Authorization") != wantAuth {
+				w.Header().Set("Www-Authenticate", `Basic realm="target"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			targetAuthOK.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test server: %v", err)
+	}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != tsURL.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, tsURL.Host)
+			}
+			return credentials.Credential{Username: username, Password: password}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/redirect", nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if !targetAuthOK.Load() {
+		t.Error("credential was not forwarded across a same-origin redirect")
+	}
+}
+
+// TestClient_send_PreservesCheckRedirect verifies that a caller-provided
+// CheckRedirect callback on the underlying HTTP client is still invoked.
+func TestClient_send_PreservesCheckRedirect(t *testing.T) {
+	var called atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/a":
+			http.Redirect(w, r, "/b", http.StatusTemporaryRedirect)
+		case "/b":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	client := &Client{
+		Client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				called.Store(true)
+				return nil
+			},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/a", nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if !called.Load() {
+		t.Error("caller-provided CheckRedirect was not invoked")
+	}
+}
+
+func Test_sameHTTPOrigin(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"identical", "http://example.com:5000", "http://example.com:5000", true},
+		{"different port", "http://example.com:5000", "http://example.com:6000", false},
+		{"default https port normalized", "https://example.com", "https://example.com:443", true},
+		{"default http port normalized", "http://example.com", "http://example.com:80", true},
+		{"scheme mismatch", "http://example.com", "https://example.com", false},
+		{"case-insensitive host", "https://Example.COM", "https://example.com", true},
+		{"different host", "https://example.com", "https://evil.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := url.Parse(tt.a)
+			if err != nil {
+				t.Fatalf("failed to parse %q: %v", tt.a, err)
+			}
+			b, err := url.Parse(tt.b)
+			if err != nil {
+				t.Fatalf("failed to parse %q: %v", tt.b, err)
+			}
+			if got := sameHTTPOrigin(a, b); got != tt.want {
+				t.Errorf("sameHTTPOrigin(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`feat/everything` already carried some, but not all, of the security advisory
patches that shipped for oras-go v2 (release v2.6.1). This backports the three
missing/incomplete ones, each as its own commit with tests.

Reference advisories: https://github.com/oras-project/oras-go/security/advisories

## Advisories addressed

| Advisory | Area | Status before | Change |
|---|---|---|---|
| **GHSA-vh4v-2xq2-g5cg** | `registry/remote/auth` | missing | Wrap the auth client's redirect handling to drop the `Authorization` header when a redirect crosses an HTTP origin (scheme/host/port, with default-port normalization), preserving any caller-provided `CheckRedirect`; and skip credential resolution when a 401 challenge comes from a different origin than originally requested. |
| **GHSA-8xwf-rjm4-xvhv** | `content/file` | missing | Add `checkSymlinkEscape` + `realPathForWrite` and call them after the lexical `filepath.Rel` boundary check in `resolveWritePath`, so a symlink component under `workingDir` pointing outside it (e.g. `out` -> `/outside`) can no longer redirect writes out of bounds when `AllowPathTraversalOnWrite=false`. |
| **GHSA-xf85-363p-868w** | `registry/remote/auth` | partial | `validateRealm` already rejected unsafe schemes and http-on-https TLS downgrades, but with the default empty `TrustedRealmHosts` it still accepted IP-literal realm hosts. Add an always-on guard that rejects loopback/link-local/private/unspecified IP literals (e.g. the metadata service `169.254.169.254`), skipped when the realm host matches the registry host. |

## Already present on `feat/everything` (no change needed)

- GHSA-jxpm-75mh-9fp7 (validate Location host before blob upload)
- 32 MiB descriptor-size DoS guard in `ReadAll`
- GHSA-28r5-37g7-p6mp (bearer realm host validation via `TrustedRealmHosts`)

## Out of scope

- GHSA-fxhp-mv3v-67qp (hardlink CWD escape) — not merged on the v2 branch, so not part of this backport.

## Testing

- `go build ./...` — clean
- `go vet ./registry/remote/auth/ ./content/file/` — clean
- `go test ./...` — passes
- `gofmt -l` on changed files — clean

New tests: cross-origin redirect (after/before auth, same-origin guard, preserved `CheckRedirect`, `sameHTTPOrigin` table), symlink write-boundary traversal, and IP-literal realm cases.